### PR TITLE
Slots can return any `object`

### DIFF
--- a/PyQt5-stubs/QtCore.pyi
+++ b/PyQt5-stubs/QtCore.pyi
@@ -42,7 +42,7 @@ class pyqtBoundSignal:
 
 # Convenient type aliases.
 PYQT_SIGNAL = typing.Union[pyqtSignal, pyqtBoundSignal]
-PYQT_SLOT = typing.Union[typing.Callable[..., None], pyqtBoundSignal]
+PYQT_SLOT = typing.Union[typing.Callable[..., object], pyqtBoundSignal]
 
 
 class QtMsgType(int): ...


### PR DESCRIPTION
There is no requirement that slots return specifically `None`, any `object` will do.