### PR TITLE
Ignore some Liskov failures in QtSensors

### DIFF
--- a/PyQt5-stubs/QtSensors.pyi
+++ b/PyQt5-stubs/QtSensors.pyi
@@ -68,7 +68,7 @@ class QAccelerometerFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QAccelerometerFilter') -> None: ...
 
-    def filter(self, reading: QAccelerometerReading) -> bool: ...
+    def filter(self, reading: QAccelerometerReading) -> bool: ...  # type: ignore[override]
 
 
 class QSensor(QtCore.QObject):
@@ -179,7 +179,7 @@ class QAltimeterFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QAltimeterFilter') -> None: ...
 
-    def filter(self, reading: QAltimeterReading) -> bool: ...
+    def filter(self, reading: QAltimeterReading) -> bool: ...  # type: ignore[override]
 
 
 class QAltimeter(QSensor):
@@ -210,7 +210,7 @@ class QAmbientLightFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QAmbientLightFilter') -> None: ...
 
-    def filter(self, reading: QAmbientLightReading) -> bool: ...
+    def filter(self, reading: QAmbientLightReading) -> bool: ...  # type: ignore[override]
 
 
 class QAmbientLightSensor(QSensor):
@@ -233,7 +233,7 @@ class QAmbientTemperatureFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QAmbientTemperatureFilter') -> None: ...
 
-    def filter(self, reading: QAmbientTemperatureReading) -> bool: ...
+    def filter(self, reading: QAmbientTemperatureReading) -> bool: ...  # type: ignore[override]
 
 
 class QAmbientTemperatureSensor(QSensor):
@@ -258,7 +258,7 @@ class QCompassFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QCompassFilter') -> None: ...
 
-    def filter(self, reading: QCompassReading) -> bool: ...
+    def filter(self, reading: QCompassReading) -> bool: ...  # type: ignore[override]
 
 
 class QCompass(QSensor):
@@ -281,7 +281,7 @@ class QDistanceFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QDistanceFilter') -> None: ...
 
-    def filter(self, reading: QDistanceReading) -> bool: ...
+    def filter(self, reading: QDistanceReading) -> bool: ...  # type: ignore[override]
 
 
 class QDistanceSensor(QSensor):
@@ -308,7 +308,7 @@ class QGyroscopeFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QGyroscopeFilter') -> None: ...
 
-    def filter(self, reading: QGyroscopeReading) -> bool: ...
+    def filter(self, reading: QGyroscopeReading) -> bool: ...  # type: ignore[override]
 
 
 class QGyroscope(QSensor):
@@ -331,7 +331,7 @@ class QHolsterFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QHolsterFilter') -> None: ...
 
-    def filter(self, reading: QHolsterReading) -> bool: ...
+    def filter(self, reading: QHolsterReading) -> bool: ...  # type: ignore[override]
 
 
 class QHolsterSensor(QSensor):
@@ -356,7 +356,7 @@ class QHumidityFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QHumidityFilter') -> None: ...
 
-    def filter(self, reading: QHumidityReading) -> bool: ...
+    def filter(self, reading: QHumidityReading) -> bool: ...  # type: ignore[override]
 
 
 class QHumiditySensor(QSensor):
@@ -379,7 +379,7 @@ class QIRProximityFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QIRProximityFilter') -> None: ...
 
-    def filter(self, reading: QIRProximityReading) -> bool: ...
+    def filter(self, reading: QIRProximityReading) -> bool: ...  # type: ignore[override]
 
 
 class QIRProximitySensor(QSensor):
@@ -406,7 +406,7 @@ class QLidFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QLidFilter') -> None: ...
 
-    def filter(self, reading: QLidReading) -> bool: ...
+    def filter(self, reading: QLidReading) -> bool: ...  # type: ignore[override]
 
 
 class QLidSensor(QSensor):
@@ -429,7 +429,7 @@ class QLightFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QLightFilter') -> None: ...
 
-    def filter(self, reading: QLightReading) -> bool: ...
+    def filter(self, reading: QLightReading) -> bool: ...  # type: ignore[override]
 
 
 class QLightSensor(QSensor):
@@ -461,7 +461,7 @@ class QMagnetometerFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QMagnetometerFilter') -> None: ...
 
-    def filter(self, reading: QMagnetometerReading) -> bool: ...
+    def filter(self, reading: QMagnetometerReading) -> bool: ...  # type: ignore[override]
 
 
 class QMagnetometer(QSensor):
@@ -496,7 +496,7 @@ class QOrientationFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QOrientationFilter') -> None: ...
 
-    def filter(self, reading: QOrientationReading) -> bool: ...
+    def filter(self, reading: QOrientationReading) -> bool: ...  # type: ignore[override]
 
 
 class QOrientationSensor(QSensor):
@@ -521,7 +521,7 @@ class QPressureFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QPressureFilter') -> None: ...
 
-    def filter(self, reading: QPressureReading) -> bool: ...
+    def filter(self, reading: QPressureReading) -> bool: ...  # type: ignore[override]
 
 
 class QPressureSensor(QSensor):
@@ -544,7 +544,7 @@ class QProximityFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QProximityFilter') -> None: ...
 
-    def filter(self, reading: QProximityReading) -> bool: ...
+    def filter(self, reading: QProximityReading) -> bool: ...  # type: ignore[override]
 
 
 class QProximitySensor(QSensor):
@@ -596,7 +596,7 @@ class QTapFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QTapFilter') -> None: ...
 
-    def filter(self, reading: QTapReading) -> bool: ...
+    def filter(self, reading: QTapReading) -> bool: ...  # type: ignore[override]
 
 
 class QTapSensor(QSensor):
@@ -624,7 +624,7 @@ class QTiltFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QTiltFilter') -> None: ...
 
-    def filter(self, reading: QTiltReading) -> bool: ...
+    def filter(self, reading: QTiltReading) -> bool: ...  # type: ignore[override]
 
 
 class QTiltSensor(QSensor):
@@ -650,7 +650,7 @@ class QRotationFilter(QSensorFilter):
     @typing.overload
     def __init__(self, a0: 'QRotationFilter') -> None: ...
 
-    def filter(self, reading: QRotationReading) -> bool: ...
+    def filter(self, reading: QRotationReading) -> bool: ...  # type: ignore[override]
 
 
 class QRotationSensor(QSensor):


### PR DESCRIPTION
I believe this relates to https://github.com/python/mypy/issues/1237.

 an example

```bash
$ venv/bin/mypy --package PyQt5-stubs --show-error-codes | grep --before 1 --after 1 Liskov
<snip>
PyQt5-stubs/QtSensors.pyi:71: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:71: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:71: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```

<details> <summary>all of them</summary>

```bash
$ venv/bin/mypy --package PyQt5-stubs --show-error-codes | grep --before 1 --after 1 Liskov
<snip>
PyQt5-stubs/QtSensors.pyi:71: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:71: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:71: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:182: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:182: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:182: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:213: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:213: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:213: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:236: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:236: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:236: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:261: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:261: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:261: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:284: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:284: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:284: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:311: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:311: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:311: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:334: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:334: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:334: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:359: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:359: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:359: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:382: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:382: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:382: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:409: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:409: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:409: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:432: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:432: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:432: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:464: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:464: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:464: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:499: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:499: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:499: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:524: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:524: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:524: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:547: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:547: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:547: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:599: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:599: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:599: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:627: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:627: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:627: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
PyQt5-stubs/QtSensors.pyi:653: error: Argument 1 of "filter" is incompatible with supertype "QSensorFilter"; supertype defines the argument type as "QSensorReading"  [override]
PyQt5-stubs/QtSensors.pyi:653: note: This violates the Liskov substitution principle
PyQt5-stubs/QtSensors.pyi:653: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```

</details>
