### PR TITLE
Implement QDialogButtonBox.StandardButton[s].__or__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [#138](https://github.com/python-qt-tools/PyQt5-stubs/pull/138) update to PyQt5 5.15.3
 * [#144](https://github.com/python-qt-tools/PyQt5-stubs/pull/144) add `QTreeWidgetItem.__lt__()` to allow sorting of items in a QTreeWidget
 
+### Changed
+* [#152](https://github.com/python-qt-tools/PyQt5-stubs/pull/152) `.__or__()` for `QDialogButtonBox.StandardButton` and `QDialogButtonBox.StandardButtons`
+
 ## 5.15.2.0
 
 ### Added

--- a/PyQt5-stubs/QtWidgets.pyi
+++ b/PyQt5-stubs/QtWidgets.pyi
@@ -3530,6 +3530,11 @@ class QDial(QAbstractSlider):
 class QDialogButtonBox(QWidget):
 
     class StandardButton(int):
+        @typing.overload  # type: ignore[override]
+        def __or__(self, other: typing.Union['QDialogButtonBox.StandardButton', 'QDialogButtonBox.StandardButtons']) -> 'QDialogButtonBox.StandardButtons': ...  # type: ignore[misc]
+        @typing.overload
+        def __or__(self, other: int) -> int: ...
+
         NoButton = ... # type: QDialogButtonBox.StandardButton
         Ok = ... # type: QDialogButtonBox.StandardButton
         Save = ... # type: QDialogButtonBox.StandardButton
@@ -3620,6 +3625,7 @@ class QDialogButtonBox(QWidget):
         def __invert__(self) -> 'QDialogButtonBox.StandardButtons': ...
         def __index__(self) -> int: ...
         def __int__(self) -> int: ...
+        def __or__(self, other: typing.Union[int, 'QDialogButtonBox.StandardButtons', 'QDialogButtonBox.StandardButton']) -> 'QDialogButtonBox.StandardButtons': ...
 
     @typing.overload
     def __init__(self, parent: typing.Optional[QWidget] = ...) -> None: ...

--- a/tests/qdialogbuttonbox.py
+++ b/tests/qdialogbuttonbox.py
@@ -1,0 +1,7 @@
+from PyQt5 import QtWidgets
+
+a = QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Ok  # type: QtWidgets.QDialogButtonBox.StandardButtons
+b = QtWidgets.QDialogButtonBox.Ok | 0  # type: int
+c = a | 0  # type: QtWidgets.QDialogButtonBox.StandardButtons
+d = a | QtWidgets.QDialogButtonBox.Ok  # type: QtWidgets.QDialogButtonBox.StandardButtons
+e = a | a  # type: QtWidgets.QDialogButtonBox.StandardButtons


### PR DESCRIPTION
Essentially the same as #109 but for `QDialogButtonBox` which needs it as well.