### PR TITLE
Drop 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
             runs-on: windows-latest
             tox: windows
         python:
-          - name: CPython 3.6
-            tox: py36
-            action: 3.6
           - name: CPython 3.7
             tox: py37
             action: 3.7

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=find_version('PyQt5-stubs', '__init__.pyi'),
-    python_requires=">= 3.5",
+    python_requires=">= 3.7",
     package_data={"PyQt5-stubs": ['*.pyi']},
     packages=["PyQt5-stubs"],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9,10}-{windows,linux}
+envlist = py3{7,8,9,10}-{windows,linux}
 
 [testenv]
 deps =


### PR DESCRIPTION
GitHub is raggedly allowing 3.5 and 3.6 support in Linux to drop from the `setup-python` action as they start using Ubuntu 22.04 instead of 20.04.  https://github.com/actions/setup-python/issues/544

Example failure at https://github.com/python-qt-tools/PyQt5-stubs/actions/runs/3645895301/jobs/6156457796#step:3:9.

```
Version 3.6.0-alpha - 3.6.X was not found in the local cache
Error: Version 3.6.0-alpha - 3.6.X with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

We could also just make our matrix ragged as well and only drop the Linux testing.  Or, explicitly call out the 20.04 runners for awhile.  Let me know what you think.